### PR TITLE
Add sequential bot login retries and respawn handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ target/
 !**/src/test/**/target/
 
 ### IntelliJ IDEA ###
-.idea/
 .idea/modules.xml
 .idea/jarRepositories.xml
 .idea/compiler.xml

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ target/
 !**/src/test/**/target/
 
 ### IntelliJ IDEA ###
+.idea/
 .idea/modules.xml
 .idea/jarRepositories.xml
 .idea/compiler.xml
@@ -33,6 +34,9 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### Claude ###
+.claude/
 
 ### Mac OS ###
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,5 @@ build/
 ### VS Code ###
 .vscode/
 
-### Claude ###
-.claude/
-
 ### Mac OS ###
 .DS_Store

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/Bot.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/Bot.java
@@ -8,6 +8,8 @@ public interface Bot {
 
     boolean isOnline();
 
+    boolean isLoggedIn();
+
     void sendMessage(String message);
 
     void executeCommand(String command);

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/ClientOptions.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/ClientOptions.java
@@ -14,6 +14,7 @@ public class ClientOptions {
     private Stage stage;
     private boolean compressed;
     private int maximumPacketSize;
+    private volatile boolean loggedIn;
 
     public ClientOptions(Stage stage, Logger logger, String name, String host, int port) {
         setStage(stage);
@@ -66,6 +67,14 @@ public class ClientOptions {
     public void setStage(Stage stage) {
         if (stage == null) throw new IllegalArgumentException("Stage cannot be null");
         this.stage = stage;
+    }
+
+    public boolean isLoggedIn() {
+        return loggedIn;
+    }
+
+    public void setLoggedIn(boolean loggedIn) {
+        this.loggedIn = loggedIn;
     }
 
 }

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_12_2/BotImpl.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_12_2/BotImpl.java
@@ -83,9 +83,8 @@ public class BotImpl implements Bot {
 
     @Override
     public void disconnect(String reason) {
-        if (channel != null) {
-            channel.disconnect();
-        }
+        if (channel == null) return;
+        channel.disconnect();
         logger.log(Level.INFO, "Disconnected: {0}", reason);
     }
 

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_12_2/BotImpl.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_12_2/BotImpl.java
@@ -20,6 +20,7 @@ public class BotImpl implements Bot {
     private Channel channel;
     private final Logger logger;
     private final String name;
+    private ClientOptions options;
 
     public BotImpl(Logger logger, String name) {
         this.logger = logger;
@@ -37,6 +38,11 @@ public class BotImpl implements Bot {
     }
 
     @Override
+    public boolean isLoggedIn() {
+        return options != null && options.isLoggedIn() && isOnline();
+    }
+
+    @Override
     public void sendMessage(String message) {
         if (isOnline()) {
             channel.writeAndFlush(new ServerBoundChatPacket(message));
@@ -51,13 +57,12 @@ public class BotImpl implements Bot {
     @Override
     public void connect(EventLoopGroup workerGroup, String host, int port) {
 
+        options = new ClientOptions(StageType.LOGIN_STAGE, logger, name, host, port);
         Bootstrap bootstrap = new Bootstrap();
         bootstrap.group(workerGroup);
         bootstrap.channel(NioSocketChannel.class);
         bootstrap.option(ChannelOption.SO_KEEPALIVE, true);
         bootstrap.handler(new ChannelInitializer<SocketChannel>() {
-
-            private final ClientOptions options = new ClientOptions(StageType.LOGIN_STAGE, logger, name, host, port);
 
             @Override
             public void initChannel(SocketChannel channel) {
@@ -78,7 +83,9 @@ public class BotImpl implements Bot {
 
     @Override
     public void disconnect(String reason) {
-        channel.disconnect();
+        if (channel != null) {
+            channel.disconnect();
+        }
         logger.log(Level.INFO, "Disconnected: {0}", reason);
     }
 

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_12_2/network/ClientHandler.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_12_2/network/ClientHandler.java
@@ -49,6 +49,7 @@ public class ClientHandler extends ChannelInboundHandlerAdapter {
         }
         if (msg instanceof ClientBoundLoginFinishedPacket) {
             options.setStage(StageType.PLAY_STAGE);
+            options.setLoggedIn(true);
             ctx.writeAndFlush(new ServerBoundRespawnPacket());
         }
         //Login end
@@ -70,11 +71,22 @@ public class ClientHandler extends ChannelInboundHandlerAdapter {
             ClientBoundSystemChatPacket packet = (ClientBoundSystemChatPacket) msg;
             if (!packet.isActionMessage() && !packet.getMessage().isEmpty()) {
                 options.getLogger().log(Level.INFO, "Received Message: {0}", packet.getMessage());
+                respawnIfDeathMessage(ctx, packet.getMessage());
             }
         }
 
         //Play End
         super.channelRead(ctx, msg);
+    }
+
+    private void respawnIfDeathMessage(ChannelHandlerContext ctx, String message) {
+        String lower = message.toLowerCase();
+        if (lower.contains("overwhelmed by") || lower.contains("slain by") || lower.contains("died")
+                || lower.contains("fell from") || lower.contains("drowned") || lower.contains("suffocated")
+                || lower.contains("burned to death") || lower.contains("blew up")) {
+            options.getLogger().info("Death detected, respawning now.");
+            ctx.writeAndFlush(new ServerBoundRespawnPacket());
+        }
     }
 
 }

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_12_2/network/ClientHandler.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_12_2/network/ClientHandler.java
@@ -71,22 +71,11 @@ public class ClientHandler extends ChannelInboundHandlerAdapter {
             ClientBoundSystemChatPacket packet = (ClientBoundSystemChatPacket) msg;
             if (!packet.isActionMessage() && !packet.getMessage().isEmpty()) {
                 options.getLogger().log(Level.INFO, "Received Message: {0}", packet.getMessage());
-                respawnIfDeathMessage(ctx, packet.getMessage());
             }
         }
 
         //Play End
         super.channelRead(ctx, msg);
-    }
-
-    private void respawnIfDeathMessage(ChannelHandlerContext ctx, String message) {
-        String lower = message.toLowerCase();
-        if (lower.contains("overwhelmed by") || lower.contains("slain by") || lower.contains("died")
-                || lower.contains("fell from") || lower.contains("drowned") || lower.contains("suffocated")
-                || lower.contains("burned to death") || lower.contains("blew up")) {
-            options.getLogger().info("Death detected, respawning now.");
-            ctx.writeAndFlush(new ServerBoundRespawnPacket());
-        }
     }
 
 }

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_18_2/BotImpl.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_18_2/BotImpl.java
@@ -83,9 +83,8 @@ public class BotImpl implements Bot {
 
     @Override
     public void disconnect(String reason) {
-        if (channel != null) {
-            channel.disconnect();
-        }
+        if (channel == null) return;
+        channel.disconnect();
         logger.log(Level.INFO, "Disconnected: {0}", reason);
     }
 

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_18_2/BotImpl.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_18_2/BotImpl.java
@@ -20,6 +20,7 @@ public class BotImpl implements Bot {
     private Channel channel;
     private final Logger logger;
     private final String name;
+    private ClientOptions options;
 
     public BotImpl(Logger logger, String name) {
         this.logger = logger;
@@ -37,6 +38,11 @@ public class BotImpl implements Bot {
     }
 
     @Override
+    public boolean isLoggedIn() {
+        return options != null && options.isLoggedIn() && isOnline();
+    }
+
+    @Override
     public void sendMessage(String message) {
         if (isOnline()) {
             channel.writeAndFlush(new ServerBoundChatPacket(message));
@@ -51,13 +57,12 @@ public class BotImpl implements Bot {
     @Override
     public void connect(EventLoopGroup workerGroup, String host, int port) {
 
+        options = new ClientOptions(StageType.LOGIN_STAGE, logger, name, host, port);
         Bootstrap bootstrap = new Bootstrap();
         bootstrap.group(workerGroup);
         bootstrap.channel(NioSocketChannel.class);
         bootstrap.option(ChannelOption.SO_KEEPALIVE, true);
         bootstrap.handler(new ChannelInitializer<SocketChannel>() {
-
-            private final ClientOptions options = new ClientOptions(StageType.LOGIN_STAGE, logger, name, host, port);
 
             @Override
             public void initChannel(SocketChannel channel) {
@@ -78,7 +83,9 @@ public class BotImpl implements Bot {
 
     @Override
     public void disconnect(String reason) {
-        channel.disconnect();
+        if (channel != null) {
+            channel.disconnect();
+        }
         logger.log(Level.INFO, "Disconnected: {0}", reason);
     }
 

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_18_2/network/ClientHandler.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_18_2/network/ClientHandler.java
@@ -49,6 +49,7 @@ public class ClientHandler extends ChannelInboundHandlerAdapter {
         }
         if (msg instanceof ClientBoundLoginFinishedPacket) {
             options.setStage(StageType.PLAY_STAGE);
+            options.setLoggedIn(true);
             ctx.writeAndFlush(new ServerBoundRespawnPacket());
         }
         //Login end
@@ -70,11 +71,22 @@ public class ClientHandler extends ChannelInboundHandlerAdapter {
             ClientBoundSystemChatPacket packet = (ClientBoundSystemChatPacket) msg;
             if (!packet.isActionMessage() && !packet.getMessage().isEmpty()) {
                 options.getLogger().log(Level.INFO, "Received Message: {0}", packet.getMessage());
+                respawnIfDeathMessage(ctx, packet.getMessage());
             }
         }
 
         //Play End
         super.channelRead(ctx, msg);
+    }
+
+    private void respawnIfDeathMessage(ChannelHandlerContext ctx, String message) {
+        String lower = message.toLowerCase();
+        if (lower.contains("overwhelmed by") || lower.contains("slain by") || lower.contains("died")
+                || lower.contains("fell from") || lower.contains("drowned") || lower.contains("suffocated")
+                || lower.contains("burned to death") || lower.contains("blew up")) {
+            options.getLogger().info("Death detected, respawning now.");
+            ctx.writeAndFlush(new ServerBoundRespawnPacket());
+        }
     }
 
 }

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_18_2/network/ClientHandler.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_18_2/network/ClientHandler.java
@@ -71,22 +71,11 @@ public class ClientHandler extends ChannelInboundHandlerAdapter {
             ClientBoundSystemChatPacket packet = (ClientBoundSystemChatPacket) msg;
             if (!packet.isActionMessage() && !packet.getMessage().isEmpty()) {
                 options.getLogger().log(Level.INFO, "Received Message: {0}", packet.getMessage());
-                respawnIfDeathMessage(ctx, packet.getMessage());
             }
         }
 
         //Play End
         super.channelRead(ctx, msg);
-    }
-
-    private void respawnIfDeathMessage(ChannelHandlerContext ctx, String message) {
-        String lower = message.toLowerCase();
-        if (lower.contains("overwhelmed by") || lower.contains("slain by") || lower.contains("died")
-                || lower.contains("fell from") || lower.contains("drowned") || lower.contains("suffocated")
-                || lower.contains("burned to death") || lower.contains("blew up")) {
-            options.getLogger().info("Death detected, respawning now.");
-            ctx.writeAndFlush(new ServerBoundRespawnPacket());
-        }
     }
 
 }

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_19_4/BotImpl.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_19_4/BotImpl.java
@@ -25,6 +25,7 @@ public class BotImpl implements Bot {
     private Channel channel;
     private final Logger logger;
     private final String name;
+    private ClientOptions options;
 
     public BotImpl(Logger logger, String name) {
         this.logger = logger;
@@ -39,6 +40,11 @@ public class BotImpl implements Bot {
     @Override
     public boolean isOnline() {
         return channel != null && channel.isActive();
+    }
+
+    @Override
+    public boolean isLoggedIn() {
+        return options != null && options.isLoggedIn() && isOnline();
     }
 
     @Override
@@ -58,13 +64,12 @@ public class BotImpl implements Bot {
     @Override
     public void connect(EventLoopGroup workerGroup, String host, int port) {
 
+        options = new ClientOptions(StageType.LOGIN_STAGE, logger, name, host, port);
         Bootstrap bootstrap = new Bootstrap();
         bootstrap.group(workerGroup);
         bootstrap.channel(NioSocketChannel.class);
         bootstrap.option(ChannelOption.SO_KEEPALIVE, true);
         bootstrap.handler(new ChannelInitializer<SocketChannel>() {
-
-            private final ClientOptions options = new ClientOptions(StageType.LOGIN_STAGE, logger, name, host, port);
 
             @Override
             public void initChannel(SocketChannel channel) {
@@ -85,7 +90,9 @@ public class BotImpl implements Bot {
 
     @Override
     public void disconnect(String reason) {
-        channel.disconnect();
+        if (channel != null) {
+            channel.disconnect();
+        }
         logger.log(Level.INFO, "Disconnected: {0}", reason);
     }
 

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_19_4/BotImpl.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_19_4/BotImpl.java
@@ -90,9 +90,8 @@ public class BotImpl implements Bot {
 
     @Override
     public void disconnect(String reason) {
-        if (channel != null) {
-            channel.disconnect();
-        }
+        if (channel == null) return;
+        channel.disconnect();
         logger.log(Level.INFO, "Disconnected: {0}", reason);
     }
 

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_19_4/network/ClientHandler.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_19_4/network/ClientHandler.java
@@ -49,6 +49,7 @@ public class ClientHandler extends ChannelInboundHandlerAdapter {
         }
         if (msg instanceof ClientBoundLoginFinishedPacket) {
             options.setStage(StageType.PLAY_STAGE);
+            options.setLoggedIn(true);
             ctx.writeAndFlush(new ServerBoundRespawnPacket());
         }
         //Login end
@@ -70,11 +71,22 @@ public class ClientHandler extends ChannelInboundHandlerAdapter {
             ClientBoundSystemChatPacket packet = (ClientBoundSystemChatPacket) msg;
             if (!packet.isActionMessage() && !packet.getMessage().isEmpty()) {
                 options.getLogger().log(Level.INFO, "Received Message: {0}", packet.getMessage());
+                respawnIfDeathMessage(ctx, packet.getMessage());
             }
         }
 
         //Play End
         super.channelRead(ctx, msg);
+    }
+
+    private void respawnIfDeathMessage(ChannelHandlerContext ctx, String message) {
+        String lower = message.toLowerCase();
+        if (lower.contains("overwhelmed by") || lower.contains("slain by") || lower.contains("died")
+                || lower.contains("fell from") || lower.contains("drowned") || lower.contains("suffocated")
+                || lower.contains("burned to death") || lower.contains("blew up")) {
+            options.getLogger().info("Death detected, respawning now.");
+            ctx.writeAndFlush(new ServerBoundRespawnPacket());
+        }
     }
 
 }

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_19_4/network/ClientHandler.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_19_4/network/ClientHandler.java
@@ -71,22 +71,11 @@ public class ClientHandler extends ChannelInboundHandlerAdapter {
             ClientBoundSystemChatPacket packet = (ClientBoundSystemChatPacket) msg;
             if (!packet.isActionMessage() && !packet.getMessage().isEmpty()) {
                 options.getLogger().log(Level.INFO, "Received Message: {0}", packet.getMessage());
-                respawnIfDeathMessage(ctx, packet.getMessage());
             }
         }
 
         //Play End
         super.channelRead(ctx, msg);
-    }
-
-    private void respawnIfDeathMessage(ChannelHandlerContext ctx, String message) {
-        String lower = message.toLowerCase();
-        if (lower.contains("overwhelmed by") || lower.contains("slain by") || lower.contains("died")
-                || lower.contains("fell from") || lower.contains("drowned") || lower.contains("suffocated")
-                || lower.contains("burned to death") || lower.contains("blew up")) {
-            options.getLogger().info("Death detected, respawning now.");
-            ctx.writeAndFlush(new ServerBoundRespawnPacket());
-        }
     }
 
 }

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_20_6/BotImpl.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_20_6/BotImpl.java
@@ -25,6 +25,7 @@ public class BotImpl implements Bot {
     private Channel channel;
     private final Logger logger;
     private final String name;
+    private ClientOptions options;
 
     public BotImpl(Logger logger, String name) {
         this.logger = logger;
@@ -39,6 +40,11 @@ public class BotImpl implements Bot {
     @Override
     public boolean isOnline() {
         return channel != null && channel.isActive();
+    }
+
+    @Override
+    public boolean isLoggedIn() {
+        return options != null && options.isLoggedIn() && isOnline();
     }
 
     @Override
@@ -58,13 +64,12 @@ public class BotImpl implements Bot {
     @Override
     public void connect(EventLoopGroup workerGroup, String host, int port) {
 
+        options = new ClientOptions(StageType.LOGIN_STAGE, logger, name, host, port);
         Bootstrap bootstrap = new Bootstrap();
         bootstrap.group(workerGroup);
         bootstrap.channel(NioSocketChannel.class);
         bootstrap.option(ChannelOption.SO_KEEPALIVE, true);
         bootstrap.handler(new ChannelInitializer<SocketChannel>() {
-
-            private final ClientOptions options = new ClientOptions(StageType.LOGIN_STAGE, logger, name, host, port);
 
             @Override
             public void initChannel(SocketChannel channel) {
@@ -85,7 +90,9 @@ public class BotImpl implements Bot {
 
     @Override
     public void disconnect(String reason) {
-        channel.disconnect();
+        if (channel != null) {
+            channel.disconnect();
+        }
         logger.log(Level.INFO, "Disconnected: {0}", reason);
     }
 

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_20_6/BotImpl.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_20_6/BotImpl.java
@@ -90,9 +90,8 @@ public class BotImpl implements Bot {
 
     @Override
     public void disconnect(String reason) {
-        if (channel != null) {
-            channel.disconnect();
-        }
+        if (channel == null) return;
+        channel.disconnect();
         logger.log(Level.INFO, "Disconnected: {0}", reason);
     }
 

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_20_6/network/ClientHandler.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_20_6/network/ClientHandler.java
@@ -65,6 +65,7 @@ public class ClientHandler extends ChannelInboundHandlerAdapter {
         }
         if (msg instanceof ClientBoundFinishConfigurationPacket) {
             options.setStage(StageType.PLAY_STAGE);
+            options.setLoggedIn(true);
             ctx.writeAndFlush(new ServerBoundFinishConfigurationPacket());
             ctx.writeAndFlush(new ServerBoundRespawnPacket());
         }
@@ -87,11 +88,22 @@ public class ClientHandler extends ChannelInboundHandlerAdapter {
             ClientBoundSystemChatPacket packet = (ClientBoundSystemChatPacket) msg;
             if (!packet.isActionMessage() && !packet.getMessage().isEmpty()) {
                 options.getLogger().log(Level.INFO, "Received Message: {0}", packet.getMessage());
+                respawnIfDeathMessage(ctx, packet.getMessage());
             }
         }
 
         //Play End
         super.channelRead(ctx, msg);
+    }
+
+    private void respawnIfDeathMessage(ChannelHandlerContext ctx, String message) {
+        String lower = message.toLowerCase();
+        if (lower.contains("overwhelmed by") || lower.contains("slain by") || lower.contains("died")
+                || lower.contains("fell from") || lower.contains("drowned") || lower.contains("suffocated")
+                || lower.contains("burned to death") || lower.contains("blew up")) {
+            options.getLogger().info("Death detected, respawning now.");
+            ctx.writeAndFlush(new ServerBoundRespawnPacket());
+        }
     }
 
 }

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_20_6/network/ClientHandler.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_20_6/network/ClientHandler.java
@@ -88,22 +88,11 @@ public class ClientHandler extends ChannelInboundHandlerAdapter {
             ClientBoundSystemChatPacket packet = (ClientBoundSystemChatPacket) msg;
             if (!packet.isActionMessage() && !packet.getMessage().isEmpty()) {
                 options.getLogger().log(Level.INFO, "Received Message: {0}", packet.getMessage());
-                respawnIfDeathMessage(ctx, packet.getMessage());
             }
         }
 
         //Play End
         super.channelRead(ctx, msg);
-    }
-
-    private void respawnIfDeathMessage(ChannelHandlerContext ctx, String message) {
-        String lower = message.toLowerCase();
-        if (lower.contains("overwhelmed by") || lower.contains("slain by") || lower.contains("died")
-                || lower.contains("fell from") || lower.contains("drowned") || lower.contains("suffocated")
-                || lower.contains("burned to death") || lower.contains("blew up")) {
-            options.getLogger().info("Death detected, respawning now.");
-            ctx.writeAndFlush(new ServerBoundRespawnPacket());
-        }
     }
 
 }

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_21_11/BotImpl.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_21_11/BotImpl.java
@@ -25,6 +25,7 @@ public class BotImpl implements Bot {
     private Channel channel;
     private final Logger logger;
     private final String name;
+    private ClientOptions options;
 
     public BotImpl(Logger logger, String name) {
         this.logger = logger;
@@ -39,6 +40,11 @@ public class BotImpl implements Bot {
     @Override
     public boolean isOnline() {
         return channel != null && channel.isActive();
+    }
+
+    @Override
+    public boolean isLoggedIn() {
+        return options != null && options.isLoggedIn() && isOnline();
     }
 
     @Override
@@ -58,13 +64,12 @@ public class BotImpl implements Bot {
     @Override
     public void connect(EventLoopGroup workerGroup, String host, int port) {
 
+        options = new ClientOptions(StageType.LOGIN_STAGE, logger, name, host, port);
         Bootstrap bootstrap = new Bootstrap();
         bootstrap.group(workerGroup);
         bootstrap.channel(NioSocketChannel.class);
         bootstrap.option(ChannelOption.SO_KEEPALIVE, true);
         bootstrap.handler(new ChannelInitializer<SocketChannel>() {
-
-            private final ClientOptions options = new ClientOptions(StageType.LOGIN_STAGE, logger, name, host, port);
 
             @Override
             public void initChannel(SocketChannel channel) {
@@ -85,7 +90,9 @@ public class BotImpl implements Bot {
 
     @Override
     public void disconnect(String reason) {
-        channel.disconnect();
+        if (channel != null) {
+            channel.disconnect();
+        }
         logger.log(Level.INFO, "Disconnected: {0}", reason);
     }
 

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_21_11/BotImpl.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_21_11/BotImpl.java
@@ -90,9 +90,8 @@ public class BotImpl implements Bot {
 
     @Override
     public void disconnect(String reason) {
-        if (channel != null) {
-            channel.disconnect();
-        }
+        if (channel == null) return;
+        channel.disconnect();
         logger.log(Level.INFO, "Disconnected: {0}", reason);
     }
 

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_21_11/network/ClientHandler.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_21_11/network/ClientHandler.java
@@ -60,6 +60,7 @@ public class ClientHandler extends ChannelInboundHandlerAdapter {
         }
         if (msg instanceof ClientBoundFinishConfigurationPacket) {
             options.setStage(StageType.PLAY_STAGE);
+            options.setLoggedIn(true);
             ctx.writeAndFlush(new ServerBoundFinishConfigurationPacket());
             ctx.writeAndFlush(new ServerBoundRespawnPacket());
         }
@@ -82,11 +83,22 @@ public class ClientHandler extends ChannelInboundHandlerAdapter {
             ClientBoundSystemChatPacket packet = (ClientBoundSystemChatPacket) msg;
             if (!packet.isActionMessage() && !packet.getMessage().isEmpty()) {
                 options.getLogger().log(Level.INFO, "Received Message: {0}", packet.getMessage());
+                respawnIfDeathMessage(ctx, packet.getMessage());
             }
         }
 
         //Play End
         super.channelRead(ctx, msg);
+    }
+
+    private void respawnIfDeathMessage(ChannelHandlerContext ctx, String message) {
+        String lower = message.toLowerCase();
+        if (lower.contains("overwhelmed by") || lower.contains("slain by") || lower.contains("died")
+                || lower.contains("fell from") || lower.contains("drowned") || lower.contains("suffocated")
+                || lower.contains("burned to death") || lower.contains("blew up")) {
+            options.getLogger().info("Death detected, respawning now.");
+            ctx.writeAndFlush(new ServerBoundRespawnPacket());
+        }
     }
 
 }

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_21_11/network/ClientHandler.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_21_11/network/ClientHandler.java
@@ -83,22 +83,11 @@ public class ClientHandler extends ChannelInboundHandlerAdapter {
             ClientBoundSystemChatPacket packet = (ClientBoundSystemChatPacket) msg;
             if (!packet.isActionMessage() && !packet.getMessage().isEmpty()) {
                 options.getLogger().log(Level.INFO, "Received Message: {0}", packet.getMessage());
-                respawnIfDeathMessage(ctx, packet.getMessage());
             }
         }
 
         //Play End
         super.channelRead(ctx, msg);
-    }
-
-    private void respawnIfDeathMessage(ChannelHandlerContext ctx, String message) {
-        String lower = message.toLowerCase();
-        if (lower.contains("overwhelmed by") || lower.contains("slain by") || lower.contains("died")
-                || lower.contains("fell from") || lower.contains("drowned") || lower.contains("suffocated")
-                || lower.contains("burned to death") || lower.contains("blew up")) {
-            options.getLogger().info("Death detected, respawning now.");
-            ctx.writeAndFlush(new ServerBoundRespawnPacket());
-        }
     }
 
 }

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_7_10/BotImpl.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_7_10/BotImpl.java
@@ -83,9 +83,8 @@ public class BotImpl implements Bot {
 
     @Override
     public void disconnect(String reason) {
-        if (channel != null) {
-            channel.disconnect();
-        }
+        if (channel == null) return;
+        channel.disconnect();
         logger.log(Level.INFO, "Disconnected: {0}", reason);
     }
 

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_7_10/BotImpl.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_7_10/BotImpl.java
@@ -20,6 +20,7 @@ public class BotImpl implements Bot {
     private Channel channel;
     private final Logger logger;
     private final String name;
+    private ClientOptions options;
 
     public BotImpl(Logger logger, String name) {
         this.logger = logger;
@@ -37,6 +38,11 @@ public class BotImpl implements Bot {
     }
 
     @Override
+    public boolean isLoggedIn() {
+        return options != null && options.isLoggedIn() && isOnline();
+    }
+
+    @Override
     public void sendMessage(String message) {
         if (isOnline()) {
             channel.writeAndFlush(new ServerBoundChatPacket(message));
@@ -51,13 +57,12 @@ public class BotImpl implements Bot {
     @Override
     public void connect(EventLoopGroup workerGroup, String host, int port) {
 
+        options = new ClientOptions(StageType.LOGIN_STAGE, logger, name, host, port);
         Bootstrap bootstrap = new Bootstrap();
         bootstrap.group(workerGroup);
         bootstrap.channel(NioSocketChannel.class);
         bootstrap.option(ChannelOption.SO_KEEPALIVE, true);
         bootstrap.handler(new ChannelInitializer<SocketChannel>() {
-
-            private final ClientOptions options = new ClientOptions(StageType.LOGIN_STAGE, logger, name, host, port);
 
             @Override
             public void initChannel(SocketChannel channel) {
@@ -78,7 +83,9 @@ public class BotImpl implements Bot {
 
     @Override
     public void disconnect(String reason) {
-        channel.disconnect();
+        if (channel != null) {
+            channel.disconnect();
+        }
         logger.log(Level.INFO, "Disconnected: {0}", reason);
     }
 

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_7_10/network/ClientHandler.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_7_10/network/ClientHandler.java
@@ -60,22 +60,11 @@ public class ClientHandler extends ChannelInboundHandlerAdapter {
             ClientBoundSystemChatPacket packet = (ClientBoundSystemChatPacket) msg;
             if (!packet.getMessage().isEmpty()) {
                 options.getLogger().log(Level.INFO, "Received Message: {0}", packet.getMessage());
-                respawnIfDeathMessage(ctx, packet.getMessage());
             }
         }
 
         //Play End
         super.channelRead(ctx, msg);
-    }
-
-    private void respawnIfDeathMessage(ChannelHandlerContext ctx, String message) {
-        String lower = message.toLowerCase();
-        if (lower.contains("overwhelmed by") || lower.contains("slain by") || lower.contains("died")
-                || lower.contains("fell from") || lower.contains("drowned") || lower.contains("suffocated")
-                || lower.contains("burned to death") || lower.contains("blew up")) {
-            options.getLogger().info("Death detected, respawning now.");
-            ctx.writeAndFlush(new ServerBoundRespawnPacket());
-        }
     }
 
 }

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_7_10/network/ClientHandler.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_7_10/network/ClientHandler.java
@@ -44,6 +44,7 @@ public class ClientHandler extends ChannelInboundHandlerAdapter {
         }
         if (msg instanceof ClientBoundLoginFinishedPacket) {
             options.setStage(StageType.PLAY_STAGE);
+            options.setLoggedIn(true);
             ctx.writeAndFlush(new ServerBoundRespawnPacket());
         }
         //Login end
@@ -59,11 +60,22 @@ public class ClientHandler extends ChannelInboundHandlerAdapter {
             ClientBoundSystemChatPacket packet = (ClientBoundSystemChatPacket) msg;
             if (!packet.getMessage().isEmpty()) {
                 options.getLogger().log(Level.INFO, "Received Message: {0}", packet.getMessage());
+                respawnIfDeathMessage(ctx, packet.getMessage());
             }
         }
 
         //Play End
         super.channelRead(ctx, msg);
+    }
+
+    private void respawnIfDeathMessage(ChannelHandlerContext ctx, String message) {
+        String lower = message.toLowerCase();
+        if (lower.contains("overwhelmed by") || lower.contains("slain by") || lower.contains("died")
+                || lower.contains("fell from") || lower.contains("drowned") || lower.contains("suffocated")
+                || lower.contains("burned to death") || lower.contains("blew up")) {
+            options.getLogger().info("Death detected, respawning now.");
+            ctx.writeAndFlush(new ServerBoundRespawnPacket());
+        }
     }
 
 }

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_8_9/BotImpl.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_8_9/BotImpl.java
@@ -83,9 +83,8 @@ public class BotImpl implements Bot {
 
     @Override
     public void disconnect(String reason) {
-        if (channel != null) {
-            channel.disconnect();
-        }
+        if (channel == null) return;
+        channel.disconnect();
         logger.log(Level.INFO, "Disconnected: {0}", reason);
     }
 

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_8_9/BotImpl.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_8_9/BotImpl.java
@@ -20,6 +20,7 @@ public class BotImpl implements Bot {
     private Channel channel;
     private final Logger logger;
     private final String name;
+    private ClientOptions options;
 
     public BotImpl(Logger logger, String name) {
         this.logger = logger;
@@ -37,6 +38,11 @@ public class BotImpl implements Bot {
     }
 
     @Override
+    public boolean isLoggedIn() {
+        return options != null && options.isLoggedIn() && isOnline();
+    }
+
+    @Override
     public void sendMessage(String message) {
         if (isOnline()) {
             channel.writeAndFlush(new ServerBoundChatPacket(message));
@@ -51,13 +57,12 @@ public class BotImpl implements Bot {
     @Override
     public void connect(EventLoopGroup workerGroup, String host, int port) {
 
+        options = new ClientOptions(StageType.LOGIN_STAGE, logger, name, host, port);
         Bootstrap bootstrap = new Bootstrap();
         bootstrap.group(workerGroup);
         bootstrap.channel(NioSocketChannel.class);
         bootstrap.option(ChannelOption.SO_KEEPALIVE, true);
         bootstrap.handler(new ChannelInitializer<SocketChannel>() {
-
-            private final ClientOptions options = new ClientOptions(StageType.LOGIN_STAGE, logger, name, host, port);
 
             @Override
             public void initChannel(SocketChannel channel) {
@@ -78,7 +83,9 @@ public class BotImpl implements Bot {
 
     @Override
     public void disconnect(String reason) {
-        channel.disconnect();
+        if (channel != null) {
+            channel.disconnect();
+        }
         logger.log(Level.INFO, "Disconnected: {0}", reason);
     }
 

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_8_9/network/ClientHandler.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_8_9/network/ClientHandler.java
@@ -68,22 +68,11 @@ public class ClientHandler extends ChannelInboundHandlerAdapter {
             ClientBoundSystemChatPacket packet = (ClientBoundSystemChatPacket) msg;
             if (!packet.isActionMessage() && !packet.getMessage().isEmpty()) {
                 options.getLogger().log(Level.INFO, "Received Message: {0}", packet.getMessage());
-                respawnIfDeathMessage(ctx, packet.getMessage());
             }
         }
 
         //Play End
         super.channelRead(ctx, msg);
-    }
-
-    private void respawnIfDeathMessage(ChannelHandlerContext ctx, String message) {
-        String lower = message.toLowerCase();
-        if (lower.contains("overwhelmed by") || lower.contains("slain by") || lower.contains("died")
-                || lower.contains("fell from") || lower.contains("drowned") || lower.contains("suffocated")
-                || lower.contains("burned to death") || lower.contains("blew up")) {
-            options.getLogger().info("Death detected, respawning now.");
-            ctx.writeAndFlush(new ServerBoundRespawnPacket());
-        }
     }
 
 }

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_8_9/network/ClientHandler.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v1_8_9/network/ClientHandler.java
@@ -49,6 +49,7 @@ public class ClientHandler extends ChannelInboundHandlerAdapter {
         }
         if (msg instanceof ClientBoundLoginFinishedPacket) {
             options.setStage(StageType.PLAY_STAGE);
+            options.setLoggedIn(true);
             ctx.writeAndFlush(new ServerBoundRespawnPacket());
         }
         //Login end
@@ -67,11 +68,22 @@ public class ClientHandler extends ChannelInboundHandlerAdapter {
             ClientBoundSystemChatPacket packet = (ClientBoundSystemChatPacket) msg;
             if (!packet.isActionMessage() && !packet.getMessage().isEmpty()) {
                 options.getLogger().log(Level.INFO, "Received Message: {0}", packet.getMessage());
+                respawnIfDeathMessage(ctx, packet.getMessage());
             }
         }
 
         //Play End
         super.channelRead(ctx, msg);
+    }
+
+    private void respawnIfDeathMessage(ChannelHandlerContext ctx, String message) {
+        String lower = message.toLowerCase();
+        if (lower.contains("overwhelmed by") || lower.contains("slain by") || lower.contains("died")
+                || lower.contains("fell from") || lower.contains("drowned") || lower.contains("suffocated")
+                || lower.contains("burned to death") || lower.contains("blew up")) {
+            options.getLogger().info("Death detected, respawning now.");
+            ctx.writeAndFlush(new ServerBoundRespawnPacket());
+        }
     }
 
 }

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v26_1/BotImpl.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v26_1/BotImpl.java
@@ -25,6 +25,7 @@ public class BotImpl implements Bot {
     private Channel channel;
     private final Logger logger;
     private final String name;
+    private ClientOptions options;
 
     public BotImpl(Logger logger, String name) {
         this.logger = logger;
@@ -39,6 +40,11 @@ public class BotImpl implements Bot {
     @Override
     public boolean isOnline() {
         return channel != null && channel.isActive();
+    }
+
+    @Override
+    public boolean isLoggedIn() {
+        return options != null && options.isLoggedIn() && isOnline();
     }
 
     @Override
@@ -58,13 +64,12 @@ public class BotImpl implements Bot {
     @Override
     public void connect(EventLoopGroup workerGroup, String host, int port) {
 
+        options = new ClientOptions(StageType.LOGIN_STAGE, logger, name, host, port);
         Bootstrap bootstrap = new Bootstrap();
         bootstrap.group(workerGroup);
         bootstrap.channel(NioSocketChannel.class);
         bootstrap.option(ChannelOption.SO_KEEPALIVE, true);
         bootstrap.handler(new ChannelInitializer<SocketChannel>() {
-
-            private final ClientOptions options = new ClientOptions(StageType.LOGIN_STAGE, logger, name, host, port);
 
             @Override
             public void initChannel(SocketChannel channel) {
@@ -85,7 +90,9 @@ public class BotImpl implements Bot {
 
     @Override
     public void disconnect(String reason) {
-        channel.disconnect();
+        if (channel != null) {
+            channel.disconnect();
+        }
         logger.log(Level.INFO, "Disconnected: {0}", reason);
     }
 

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v26_1/BotImpl.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v26_1/BotImpl.java
@@ -90,9 +90,8 @@ public class BotImpl implements Bot {
 
     @Override
     public void disconnect(String reason) {
-        if (channel != null) {
-            channel.disconnect();
-        }
+        if (channel == null) return;
+        channel.disconnect();
         logger.log(Level.INFO, "Disconnected: {0}", reason);
     }
 

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v26_1/network/ClientHandler.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v26_1/network/ClientHandler.java
@@ -60,6 +60,7 @@ public class ClientHandler extends ChannelInboundHandlerAdapter {
         }
         if (msg instanceof ClientBoundFinishConfigurationPacket) {
             options.setStage(StageType.PLAY_STAGE);
+            options.setLoggedIn(true);
             ctx.writeAndFlush(new ServerBoundFinishConfigurationPacket());
             ctx.writeAndFlush(new ServerBoundRespawnPacket());
         }
@@ -82,11 +83,22 @@ public class ClientHandler extends ChannelInboundHandlerAdapter {
             ClientBoundSystemChatPacket packet = (ClientBoundSystemChatPacket) msg;
             if (!packet.isActionMessage() && !packet.getMessage().isEmpty()) {
                 options.getLogger().log(Level.INFO, "Received Message: {0}", packet.getMessage());
+                respawnIfDeathMessage(ctx, packet.getMessage());
             }
         }
 
         //Play End
         super.channelRead(ctx, msg);
+    }
+
+    private void respawnIfDeathMessage(ChannelHandlerContext ctx, String message) {
+        String lower = message.toLowerCase();
+        if (lower.contains("overwhelmed by") || lower.contains("slain by") || lower.contains("died")
+                || lower.contains("fell from") || lower.contains("drowned") || lower.contains("suffocated")
+                || lower.contains("burned to death") || lower.contains("blew up")) {
+            options.getLogger().info("Death detected, respawning now.");
+            ctx.writeAndFlush(new ServerBoundRespawnPacket());
+        }
     }
 
 }

--- a/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v26_1/network/ClientHandler.java
+++ b/bot-creator-api/src/main/java/ro/fr33styler/botcreator/bot/protocol/v26_1/network/ClientHandler.java
@@ -83,22 +83,11 @@ public class ClientHandler extends ChannelInboundHandlerAdapter {
             ClientBoundSystemChatPacket packet = (ClientBoundSystemChatPacket) msg;
             if (!packet.isActionMessage() && !packet.getMessage().isEmpty()) {
                 options.getLogger().log(Level.INFO, "Received Message: {0}", packet.getMessage());
-                respawnIfDeathMessage(ctx, packet.getMessage());
             }
         }
 
         //Play End
         super.channelRead(ctx, msg);
-    }
-
-    private void respawnIfDeathMessage(ChannelHandlerContext ctx, String message) {
-        String lower = message.toLowerCase();
-        if (lower.contains("overwhelmed by") || lower.contains("slain by") || lower.contains("died")
-                || lower.contains("fell from") || lower.contains("drowned") || lower.contains("suffocated")
-                || lower.contains("burned to death") || lower.contains("blew up")) {
-            options.getLogger().info("Death detected, respawning now.");
-            ctx.writeAndFlush(new ServerBoundRespawnPacket());
-        }
     }
 
 }

--- a/bot-creator-main/src/main/java/ro/fr33styler/botcreator/BotLauncher.java
+++ b/bot-creator-main/src/main/java/ro/fr33styler/botcreator/BotLauncher.java
@@ -1,0 +1,95 @@
+package ro.fr33styler.botcreator;
+
+import io.netty.channel.EventLoopGroup;
+import ro.fr33styler.botcreator.bot.Bot;
+
+import java.util.Collection;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+public class BotLauncher {
+
+    private static final long LOGIN_TIMEOUT_MS = 30000L;
+    private static final long CONNECT_TIMEOUT_MS = 5000L;
+    private static final long LOGIN_POLL_MS = 50L;
+
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread t = new Thread(r, "BotLauncher");
+        t.setDaemon(true);
+        return t;
+    });
+
+    private final Logger logger;
+    private final Collection<Bot> bots;
+    private final EventLoopGroup workerGroup;
+    private final String host;
+    private final int port;
+    private final int joinDelay;
+    private final int retryDelay;
+
+    public BotLauncher(Logger logger, Collection<Bot> bots, EventLoopGroup workerGroup, String host, int port, int joinDelay, int retryDelay) {
+        this.logger = logger;
+        this.bots = bots;
+        this.workerGroup = workerGroup;
+        this.host = host;
+        this.port = port;
+        this.joinDelay = joinDelay;
+        this.retryDelay = retryDelay;
+    }
+
+    public void start() {
+        scheduler.submit(this::runCycle);
+    }
+
+    private void runCycle() {
+        for (Bot bot : bots) {
+            if (bot.isLoggedIn()) {
+                continue;
+            }
+
+            if (!bot.isOnline()) {
+                bot.connect(workerGroup, host, port);
+            }
+
+            long now = System.currentTimeMillis();
+            awaitLogin(bot, now + LOGIN_TIMEOUT_MS, now + CONNECT_TIMEOUT_MS, false);
+            return;
+        }
+
+        scheduler.schedule(this::runCycle, Math.max(1000, retryDelay), TimeUnit.MILLISECONDS);
+    }
+
+    private void awaitLogin(Bot bot, long deadline, long connectDeadline, boolean wasOnline) {
+        long now = System.currentTimeMillis();
+
+        if (bot.isLoggedIn()) {
+            scheduler.schedule(this::runCycle, joinDelay, TimeUnit.MILLISECONDS);
+            return;
+        }
+
+        if (bot.isOnline()) {
+            wasOnline = true;
+        } else if (wasOnline || now >= connectDeadline) {
+            onLoginFailed(bot);
+            return;
+        }
+
+        if (now >= deadline) {
+            onLoginFailed(bot);
+            return;
+        }
+
+        final boolean nextWasOnline = wasOnline;
+        scheduler.schedule(() -> awaitLogin(bot, deadline, connectDeadline, nextWasOnline), LOGIN_POLL_MS, TimeUnit.MILLISECONDS);
+    }
+
+    private void onLoginFailed(Bot bot) {
+        logger.warning(bot.getName() + " did not finish logging in, retrying later...");
+        if (bot.isOnline()) {
+            bot.disconnect("Retrying login");
+        }
+        scheduler.schedule(this::runCycle, retryDelay, TimeUnit.MILLISECONDS);
+    }
+}

--- a/bot-creator-main/src/main/java/ro/fr33styler/botcreator/Main.java
+++ b/bot-creator-main/src/main/java/ro/fr33styler/botcreator/Main.java
@@ -3,23 +3,25 @@ package ro.fr33styler.botcreator;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.nio.NioIoHandler;
-import ro.fr33styler.botcreator.bot.Bot;
 import ro.fr33styler.botcreator.arguments.Arguments;
+import ro.fr33styler.botcreator.bot.Bot;
 import ro.fr33styler.botcreator.gui.Gui;
 
 import javax.swing.*;
 import java.awt.*;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Scanner;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class Main {
 
     public static final Logger LOGGER = Logger.getLogger("BotCreator");
+    private static final long LOGIN_TIMEOUT_MS = 30000L;
 
     public static void main(String[] args) {
-
         EventLoopGroup workerGroup = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
         if (args.length > 0) {
             Arguments arguments;
@@ -36,15 +38,15 @@ public class Main {
             LOGGER.info("Bot Creator has started!");
 
             for (int i = 0; i < arguments.getClients(); i++) {
-                String name = "Bot_" + (i + 1);
+                String name = "Bot_" + i;
                 Logger botLogger = Logger.getLogger(name);
                 botLogger.setParent(LOGGER);
+
                 Bot bot = arguments.getVersion().getProtocol().newBot(botLogger, name);
-                bot.connect(workerGroup, arguments.getHost(), arguments.getPort());
-                if (bot.isOnline()) {
-                    bots.add(bot);
-                }
+                bots.add(bot);
             }
+
+            startBotLauncher(bots, workerGroup, arguments.getHost(), arguments.getPort(), arguments.getJoinDelay(), arguments.getRetryDelay());
 
             if (bots.isEmpty()) {
                 workerGroup.shutdownGracefully();
@@ -57,6 +59,9 @@ public class Main {
                         break;
                     }
                     for (Bot bot : bots) {
+                        if (!bot.isLoggedIn()) {
+                            continue;
+                        }
                         if (message.startsWith("/")) {
                             bot.executeCommand(message);
                         } else {
@@ -66,19 +71,17 @@ public class Main {
                 }
             }
         } else {
-
             System.setProperty("sun.java2d.noddraw", "true");
             try {
                 UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
-            } catch (Exception ignored) {}
+            } catch (Exception ignored) {
+            }
 
             JFrame frame = new JFrame("BotCreator");
-
             frame.setResizable(false);
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
 
             Gui gui = new Gui(LOGGER);
-
             frame.add(gui.getTopPanel(workerGroup), BorderLayout.PAGE_START);
             frame.add(gui.getCenterPanel(), BorderLayout.CENTER);
             frame.add(gui.getBottomPanel(), BorderLayout.PAGE_END);
@@ -91,4 +94,60 @@ public class Main {
         }
     }
 
+    private static void startBotLauncher(Collection<Bot> bots, EventLoopGroup workerGroup, String host, int port, int joinDelay, int retryDelay) {
+        Thread thread = new Thread(() -> {
+            for (Bot bot : bots) {
+                while (!bot.isLoggedIn()) {
+                    if (!bot.isOnline()) {
+                        bot.connect(workerGroup, host, port);
+                    }
+                    if (waitForLogin(bot, LOGIN_TIMEOUT_MS)) {
+                        break;
+                    }
+
+                    LOGGER.warning(bot.getName() + " did not finish logging in, retrying...");
+                    if (bot.isOnline()) {
+                        bot.disconnect("Retrying login");
+                    }
+
+                    try {
+                        Thread.sleep(retryDelay);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                }
+
+                try {
+                    if (joinDelay > 0) {
+                        Thread.sleep(joinDelay);
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+        }, "BotLauncher");
+        thread.setDaemon(true);
+        thread.start();
+    }
+
+    private static boolean waitForLogin(Bot bot, long timeoutMs) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            if (bot.isLoggedIn()) {
+                return true;
+            }
+            if (!bot.isOnline()) {
+                return false;
+            }
+            try {
+                Thread.sleep(50L);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+        }
+        return bot.isLoggedIn();
+    }
 }

--- a/bot-creator-main/src/main/java/ro/fr33styler/botcreator/Main.java
+++ b/bot-creator-main/src/main/java/ro/fr33styler/botcreator/Main.java
@@ -20,6 +20,7 @@ public class Main {
 
     public static final Logger LOGGER = Logger.getLogger("BotCreator");
     private static final long LOGIN_TIMEOUT_MS = 30000L;
+    private static final long CONNECT_TIMEOUT_MS = 5000L;
 
     public static void main(String[] args) {
         EventLoopGroup workerGroup = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
@@ -113,8 +114,7 @@ public class Main {
                     }
 
                     allLoggedIn = false;
-                    connectOnce(bot, workerGroup, host, port, retryDelay);
-                    if (!sleep(joinDelay)) {
+                    if (!connectOnce(bot, workerGroup, host, port, retryDelay) || !sleep(joinDelay)) {
                         return;
                     }
                 }
@@ -153,13 +153,17 @@ public class Main {
         }
     }
 
-    private static void connectOnce(Bot bot, EventLoopGroup workerGroup, String host, int port, int retryDelay) {
+    private static boolean connectOnce(Bot bot, EventLoopGroup workerGroup, String host, int port, int retryDelay) {
         if (!bot.isOnline()) {
             bot.connect(workerGroup, host, port);
         }
 
         if (waitForLogin(bot, LOGIN_TIMEOUT_MS)) {
-            return;
+            return true;
+        }
+
+        if (Thread.currentThread().isInterrupted()) {
+            return false;
         }
 
         LOGGER.warning(bot.getName() + " did not finish logging in, retrying later...");
@@ -167,7 +171,7 @@ public class Main {
             bot.disconnect("Retrying login");
         }
 
-        sleep(retryDelay);
+        return sleep(retryDelay);
     }
 
     private static boolean sleep(int delay) {
@@ -184,20 +188,25 @@ public class Main {
     }
 
     private static boolean waitForLogin(Bot bot, long timeoutMs) {
-        long deadline = System.currentTimeMillis() + timeoutMs;
-        while (System.currentTimeMillis() < deadline) {
+        long now = System.currentTimeMillis();
+        long deadline = now + timeoutMs;
+        long connectDeadline = now + CONNECT_TIMEOUT_MS;
+        boolean wasOnline = false;
+
+        while (now < deadline) {
             if (bot.isLoggedIn()) {
                 return true;
             }
-            if (!bot.isOnline()) {
+            if (bot.isOnline()) {
+                wasOnline = true;
+            } else if (wasOnline || now >= connectDeadline) {
                 return false;
             }
-            try {
-                Thread.sleep(50L);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
+
+            if (!sleep(50)) {
                 return false;
             }
+            now = System.currentTimeMillis();
         }
         return bot.isLoggedIn();
     }

--- a/bot-creator-main/src/main/java/ro/fr33styler/botcreator/Main.java
+++ b/bot-creator-main/src/main/java/ro/fr33styler/botcreator/Main.java
@@ -46,7 +46,7 @@ public class Main {
                 bots.add(bot);
             }
 
-            startBotLauncher(bots, workerGroup, arguments.getHost(), arguments.getPort(), arguments.getJoinDelay(), arguments.getRetryDelay());
+            startBotLauncher(bots, workerGroup, arguments.getHost(), arguments.getPort(), arguments.getJoinDelay(), arguments.getRetryDelay(), arguments.getMaxOnline());
 
             if (bots.isEmpty()) {
                 workerGroup.shutdownGracefully();
@@ -94,12 +94,17 @@ public class Main {
         }
     }
 
-    private static void startBotLauncher(Collection<Bot> bots, EventLoopGroup workerGroup, String host, int port, int joinDelay, int retryDelay) {
+    private static void startBotLauncher(Collection<Bot> bots, EventLoopGroup workerGroup, String host, int port, int joinDelay, int retryDelay, int maxOnline) {
         Thread thread = new Thread(() -> {
             while (!Thread.currentThread().isInterrupted()) {
+                int activeLimit = maxOnline > 0 ? Math.min(maxOnline, bots.size()) : bots.size();
+                int checked = 0;
                 boolean allLoggedIn = true;
 
                 for (Bot bot : bots) {
+                    if (checked++ >= activeLimit) {
+                        break;
+                    }
                     if (bot.isLoggedIn()) {
                         continue;
                     }

--- a/bot-creator-main/src/main/java/ro/fr33styler/botcreator/Main.java
+++ b/bot-creator-main/src/main/java/ro/fr33styler/botcreator/Main.java
@@ -46,6 +46,7 @@ public class Main {
                 bots.add(bot);
             }
 
+            logLauncherSettings(bots.size(), arguments.getJoinDelay(), arguments.getRetryDelay(), arguments.getMaxOnline());
             startBotLauncher(bots, workerGroup, arguments.getHost(), arguments.getPort(), arguments.getJoinDelay(), arguments.getRetryDelay(), arguments.getMaxOnline());
 
             if (bots.isEmpty()) {
@@ -97,9 +98,11 @@ public class Main {
     private static void startBotLauncher(Collection<Bot> bots, EventLoopGroup workerGroup, String host, int port, int joinDelay, int retryDelay, int maxOnline) {
         Thread thread = new Thread(() -> {
             while (!Thread.currentThread().isInterrupted()) {
-                int activeLimit = maxOnline > 0 ? Math.min(maxOnline, bots.size()) : bots.size();
+                int activeLimit = getActiveLimit(bots.size(), maxOnline);
                 int checked = 0;
                 boolean allLoggedIn = true;
+
+                disconnectAboveLimit(bots, activeLimit);
 
                 for (Bot bot : bots) {
                     if (checked++ >= activeLimit) {
@@ -123,6 +126,31 @@ public class Main {
         }, "BotLauncher");
         thread.setDaemon(true);
         thread.start();
+    }
+
+    private static void logLauncherSettings(int bots, int joinDelay, int retryDelay, int maxOnline) {
+        int activeLimit = getActiveLimit(bots, maxOnline);
+        String maxOnlineMessage = maxOnline > 0 ? String.valueOf(activeLimit) : "unlimited";
+        LOGGER.info("Launcher settings: clients=" + bots + ", maxOnline=" + maxOnlineMessage + ", joinDelay=" + joinDelay + "ms, retryDelay=" + retryDelay + "ms");
+        if (maxOnline > 0 && activeLimit < bots) {
+            LOGGER.info("Max online limit active: only Bot_0 through Bot_" + (activeLimit - 1) + " will be kept online.");
+        }
+    }
+
+    private static int getActiveLimit(int bots, int maxOnline) {
+        return maxOnline > 0 ? Math.min(maxOnline, bots) : bots;
+    }
+
+    private static void disconnectAboveLimit(Collection<Bot> bots, int activeLimit) {
+        int checked = 0;
+        for (Bot bot : bots) {
+            if (checked++ < activeLimit) {
+                continue;
+            }
+            if (bot.isOnline()) {
+                bot.disconnect("Max online limit reached");
+            }
+        }
     }
 
     private static void connectOnce(Bot bot, EventLoopGroup workerGroup, String host, int port, int retryDelay) {

--- a/bot-creator-main/src/main/java/ro/fr33styler/botcreator/Main.java
+++ b/bot-creator-main/src/main/java/ro/fr33styler/botcreator/Main.java
@@ -96,40 +96,58 @@ public class Main {
 
     private static void startBotLauncher(Collection<Bot> bots, EventLoopGroup workerGroup, String host, int port, int joinDelay, int retryDelay) {
         Thread thread = new Thread(() -> {
-            for (Bot bot : bots) {
-                while (!bot.isLoggedIn()) {
-                    if (!bot.isOnline()) {
-                        bot.connect(workerGroup, host, port);
-                    }
-                    if (waitForLogin(bot, LOGIN_TIMEOUT_MS)) {
-                        break;
+            while (!Thread.currentThread().isInterrupted()) {
+                boolean allLoggedIn = true;
+
+                for (Bot bot : bots) {
+                    if (bot.isLoggedIn()) {
+                        continue;
                     }
 
-                    LOGGER.warning(bot.getName() + " did not finish logging in, retrying...");
-                    if (bot.isOnline()) {
-                        bot.disconnect("Retrying login");
-                    }
-
-                    try {
-                        Thread.sleep(retryDelay);
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
+                    allLoggedIn = false;
+                    connectOnce(bot, workerGroup, host, port, retryDelay);
+                    if (!sleep(joinDelay)) {
                         return;
                     }
                 }
 
-                try {
-                    if (joinDelay > 0) {
-                        Thread.sleep(joinDelay);
-                    }
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
+                if (allLoggedIn && !sleep(Math.max(1000, retryDelay))) {
                     return;
                 }
             }
         }, "BotLauncher");
         thread.setDaemon(true);
         thread.start();
+    }
+
+    private static void connectOnce(Bot bot, EventLoopGroup workerGroup, String host, int port, int retryDelay) {
+        if (!bot.isOnline()) {
+            bot.connect(workerGroup, host, port);
+        }
+
+        if (waitForLogin(bot, LOGIN_TIMEOUT_MS)) {
+            return;
+        }
+
+        LOGGER.warning(bot.getName() + " did not finish logging in, retrying later...");
+        if (bot.isOnline()) {
+            bot.disconnect("Retrying login");
+        }
+
+        sleep(retryDelay);
+    }
+
+    private static boolean sleep(int delay) {
+        if (delay <= 0) {
+            return true;
+        }
+        try {
+            Thread.sleep(delay);
+            return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
     }
 
     private static boolean waitForLogin(Bot bot, long timeoutMs) {

--- a/bot-creator-main/src/main/java/ro/fr33styler/botcreator/Main.java
+++ b/bot-creator-main/src/main/java/ro/fr33styler/botcreator/Main.java
@@ -44,9 +44,7 @@ public class Main {
                 bots.add(bot);
             }
 
-            Thread botLauncherThread = new Thread(new BotLauncher(LOGGER, bots, workerGroup, arguments.getHost(), arguments.getPort(), arguments.getJoinDelay(), arguments.getRetryDelay()), "BotLauncher");
-            botLauncherThread.setDaemon(true);
-            botLauncherThread.start();
+            new BotLauncher(LOGGER, bots, workerGroup, arguments.getHost(), arguments.getPort(), arguments.getJoinDelay(), arguments.getRetryDelay()).start();
 
             if (bots.isEmpty()) {
                 workerGroup.shutdownGracefully();

--- a/bot-creator-main/src/main/java/ro/fr33styler/botcreator/Main.java
+++ b/bot-creator-main/src/main/java/ro/fr33styler/botcreator/Main.java
@@ -10,7 +10,6 @@ import ro.fr33styler.botcreator.gui.Gui;
 import javax.swing.*;
 import java.awt.*;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Scanner;
 import java.util.logging.Level;
@@ -19,8 +18,6 @@ import java.util.logging.Logger;
 public class Main {
 
     public static final Logger LOGGER = Logger.getLogger("BotCreator");
-    private static final long LOGIN_TIMEOUT_MS = 30000L;
-    private static final long CONNECT_TIMEOUT_MS = 5000L;
 
     public static void main(String[] args) {
         EventLoopGroup workerGroup = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
@@ -47,8 +44,9 @@ public class Main {
                 bots.add(bot);
             }
 
-            logLauncherSettings(bots.size(), arguments.getJoinDelay(), arguments.getRetryDelay(), arguments.getMaxOnline());
-            startBotLauncher(bots, workerGroup, arguments.getHost(), arguments.getPort(), arguments.getJoinDelay(), arguments.getRetryDelay(), arguments.getMaxOnline());
+            Thread botLauncherThread = new Thread(new BotLauncher(LOGGER, bots, workerGroup, arguments.getHost(), arguments.getPort(), arguments.getJoinDelay(), arguments.getRetryDelay()), "BotLauncher");
+            botLauncherThread.setDaemon(true);
+            botLauncherThread.start();
 
             if (bots.isEmpty()) {
                 workerGroup.shutdownGracefully();
@@ -96,118 +94,4 @@ public class Main {
         }
     }
 
-    private static void startBotLauncher(Collection<Bot> bots, EventLoopGroup workerGroup, String host, int port, int joinDelay, int retryDelay, int maxOnline) {
-        Thread thread = new Thread(() -> {
-            while (!Thread.currentThread().isInterrupted()) {
-                int activeLimit = getActiveLimit(bots.size(), maxOnline);
-                int checked = 0;
-                boolean allLoggedIn = true;
-
-                disconnectAboveLimit(bots, activeLimit);
-
-                for (Bot bot : bots) {
-                    if (checked++ >= activeLimit) {
-                        break;
-                    }
-                    if (bot.isLoggedIn()) {
-                        continue;
-                    }
-
-                    allLoggedIn = false;
-                    if (!connectOnce(bot, workerGroup, host, port, retryDelay) || !sleep(joinDelay)) {
-                        return;
-                    }
-                }
-
-                if (allLoggedIn && !sleep(Math.max(1000, retryDelay))) {
-                    return;
-                }
-            }
-        }, "BotLauncher");
-        thread.setDaemon(true);
-        thread.start();
-    }
-
-    private static void logLauncherSettings(int bots, int joinDelay, int retryDelay, int maxOnline) {
-        int activeLimit = getActiveLimit(bots, maxOnline);
-        String maxOnlineMessage = maxOnline > 0 ? String.valueOf(activeLimit) : "unlimited";
-        LOGGER.info("Launcher settings: clients=" + bots + ", maxOnline=" + maxOnlineMessage + ", joinDelay=" + joinDelay + "ms, retryDelay=" + retryDelay + "ms");
-        if (maxOnline > 0 && activeLimit < bots) {
-            LOGGER.info("Max online limit active: only Bot_0 through Bot_" + (activeLimit - 1) + " will be kept online.");
-        }
-    }
-
-    private static int getActiveLimit(int bots, int maxOnline) {
-        return maxOnline > 0 ? Math.min(maxOnline, bots) : bots;
-    }
-
-    private static void disconnectAboveLimit(Collection<Bot> bots, int activeLimit) {
-        int checked = 0;
-        for (Bot bot : bots) {
-            if (checked++ < activeLimit) {
-                continue;
-            }
-            if (bot.isOnline()) {
-                bot.disconnect("Max online limit reached");
-            }
-        }
-    }
-
-    private static boolean connectOnce(Bot bot, EventLoopGroup workerGroup, String host, int port, int retryDelay) {
-        if (!bot.isOnline()) {
-            bot.connect(workerGroup, host, port);
-        }
-
-        if (waitForLogin(bot, LOGIN_TIMEOUT_MS)) {
-            return true;
-        }
-
-        if (Thread.currentThread().isInterrupted()) {
-            return false;
-        }
-
-        LOGGER.warning(bot.getName() + " did not finish logging in, retrying later...");
-        if (bot.isOnline()) {
-            bot.disconnect("Retrying login");
-        }
-
-        return sleep(retryDelay);
-    }
-
-    private static boolean sleep(int delay) {
-        if (delay <= 0) {
-            return true;
-        }
-        try {
-            Thread.sleep(delay);
-            return true;
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            return false;
-        }
-    }
-
-    private static boolean waitForLogin(Bot bot, long timeoutMs) {
-        long now = System.currentTimeMillis();
-        long deadline = now + timeoutMs;
-        long connectDeadline = now + CONNECT_TIMEOUT_MS;
-        boolean wasOnline = false;
-
-        while (now < deadline) {
-            if (bot.isLoggedIn()) {
-                return true;
-            }
-            if (bot.isOnline()) {
-                wasOnline = true;
-            } else if (wasOnline || now >= connectDeadline) {
-                return false;
-            }
-
-            if (!sleep(50)) {
-                return false;
-            }
-            now = System.currentTimeMillis();
-        }
-        return bot.isLoggedIn();
-    }
 }

--- a/bot-creator-main/src/main/java/ro/fr33styler/botcreator/arguments/Arguments.java
+++ b/bot-creator-main/src/main/java/ro/fr33styler/botcreator/arguments/Arguments.java
@@ -12,6 +12,8 @@ public class Arguments {
 
     private int clients = 1;
     private ProtocolVersion version = ProtocolVersion.values()[0];
+    private int joinDelay = 1000;
+    private int retryDelay = 3000;
 
     public String getHost() {
         return host;
@@ -27,6 +29,14 @@ public class Arguments {
 
     public ProtocolVersion getVersion() {
         return version;
+    }
+
+    public int getJoinDelay() {
+        return joinDelay;
+    }
+
+    public int getRetryDelay() {
+        return retryDelay;
     }
 
     public static Arguments parse(String[] args) throws IllegalArgumentException {
@@ -84,6 +94,26 @@ public class Arguments {
                     }
 
                     arguments.version = protocolVersion;
+                };
+            case "-join-delay":
+            case "-jd":
+                return argument -> {
+                    try {
+                        arguments.joinDelay = Integer.parseInt(argument);
+                        if (arguments.joinDelay < 0) throw new IllegalArgumentException("Join delay must be non-negative!");
+                    } catch (NumberFormatException exception) {
+                        throw new IllegalArgumentException("Invalid join delay number!");
+                    }
+                };
+            case "-retry-delay":
+            case "-rd":
+                return argument -> {
+                    try {
+                        arguments.retryDelay = Integer.parseInt(argument);
+                        if (arguments.retryDelay < 0) throw new IllegalArgumentException("Retry delay must be non-negative!");
+                    } catch (NumberFormatException exception) {
+                        throw new IllegalArgumentException("Invalid retry delay number!");
+                    }
                 };
             default: throw new IllegalArgumentException("The argument \"" + currentArgument + "\" is invalid!");
         }

--- a/bot-creator-main/src/main/java/ro/fr33styler/botcreator/arguments/Arguments.java
+++ b/bot-creator-main/src/main/java/ro/fr33styler/botcreator/arguments/Arguments.java
@@ -14,6 +14,7 @@ public class Arguments {
     private ProtocolVersion version = ProtocolVersion.values()[0];
     private int joinDelay = 1000;
     private int retryDelay = 3000;
+    private int maxOnline;
 
     public String getHost() {
         return host;
@@ -37,6 +38,10 @@ public class Arguments {
 
     public int getRetryDelay() {
         return retryDelay;
+    }
+
+    public int getMaxOnline() {
+        return maxOnline;
     }
 
     public static Arguments parse(String[] args) throws IllegalArgumentException {
@@ -113,6 +118,16 @@ public class Arguments {
                         if (arguments.retryDelay < 0) throw new IllegalArgumentException("Retry delay must be non-negative!");
                     } catch (NumberFormatException exception) {
                         throw new IllegalArgumentException("Invalid retry delay number!");
+                    }
+                };
+            case "-max-online":
+            case "-mo":
+                return argument -> {
+                    try {
+                        arguments.maxOnline = Integer.parseInt(argument);
+                        if (arguments.maxOnline < 0) throw new IllegalArgumentException("Max online must be non-negative!");
+                    } catch (NumberFormatException exception) {
+                        throw new IllegalArgumentException("Invalid max online number!");
                     }
                 };
             default: throw new IllegalArgumentException("The argument \"" + currentArgument + "\" is invalid!");

--- a/bot-creator-main/src/main/java/ro/fr33styler/botcreator/arguments/Arguments.java
+++ b/bot-creator-main/src/main/java/ro/fr33styler/botcreator/arguments/Arguments.java
@@ -14,7 +14,6 @@ public class Arguments {
     private ProtocolVersion version = ProtocolVersion.values()[0];
     private int joinDelay = 1000;
     private int retryDelay = 3000;
-    private int maxOnline;
 
     public String getHost() {
         return host;
@@ -38,10 +37,6 @@ public class Arguments {
 
     public int getRetryDelay() {
         return retryDelay;
-    }
-
-    public int getMaxOnline() {
-        return maxOnline;
     }
 
     public static Arguments parse(String[] args) throws IllegalArgumentException {
@@ -118,16 +113,6 @@ public class Arguments {
                         if (arguments.retryDelay < 0) throw new IllegalArgumentException("Retry delay must be non-negative!");
                     } catch (NumberFormatException exception) {
                         throw new IllegalArgumentException("Invalid retry delay number!");
-                    }
-                };
-            case "-max-online":
-            case "-mo":
-                return argument -> {
-                    try {
-                        arguments.maxOnline = Integer.parseInt(argument);
-                        if (arguments.maxOnline < 0) throw new IllegalArgumentException("Max online must be non-negative!");
-                    } catch (NumberFormatException exception) {
-                        throw new IllegalArgumentException("Invalid max online number!");
                     }
                 };
             default: throw new IllegalArgumentException("The argument \"" + currentArgument + "\" is invalid!");

--- a/bot-creator-main/src/main/java/ro/fr33styler/botcreator/gui/ConnectListener.java
+++ b/bot-creator-main/src/main/java/ro/fr33styler/botcreator/gui/ConnectListener.java
@@ -12,6 +12,8 @@ import java.util.logging.Logger;
 
 public class ConnectListener implements ActionListener {
 
+    private static final long LOGIN_TIMEOUT_MS = 30000L;
+
     private final Logger logger;
     private final Deque<Bot> bots;
     private final EventLoopGroup workerGroup;
@@ -20,11 +22,13 @@ public class ConnectListener implements ActionListener {
     private final JTextField hostInput;
     private final JTextField portInput;
     private final JTextField clientsInput;
+    private final JTextField joinDelayInput;
+    private final JTextField retryDelayInput;
     private final JComboBox<String> versionsBox;
 
     private final JComboBox<String> botsBox;
 
-    public ConnectListener(Logger logger, Deque<Bot> bots, EventLoopGroup workerGroup, JTextField hostInput, JTextField portInput, JTextField clientsInput, JComboBox<String> versionsBox, JButton connect, JComboBox<String> botsBox) {
+    public ConnectListener(Logger logger, Deque<Bot> bots, EventLoopGroup workerGroup, JTextField hostInput, JTextField portInput, JTextField clientsInput, JTextField joinDelayInput, JTextField retryDelayInput, JComboBox<String> versionsBox, JButton connect, JComboBox<String> botsBox) {
         this.logger = logger;
         this.bots = bots;
         this.workerGroup = workerGroup;
@@ -32,6 +36,8 @@ public class ConnectListener implements ActionListener {
         this.hostInput = hostInput;
         this.portInput = portInput;
         this.clientsInput = clientsInput;
+        this.joinDelayInput = joinDelayInput;
+        this.retryDelayInput = retryDelayInput;
         this.versionsBox = versionsBox;
 
         this.connect = connect;
@@ -61,6 +67,24 @@ public class ConnectListener implements ActionListener {
             return;
         }
 
+        int joinDelay;
+        try {
+            joinDelay = Integer.parseInt(joinDelayInput.getText());
+            if (joinDelay < 0) throw new NumberFormatException();
+        } catch (NumberFormatException exception) {
+            logger.severe("The join delay must be a non-negative number!");
+            return;
+        }
+
+        int retryDelay;
+        try {
+            retryDelay = Integer.parseInt(retryDelayInput.getText());
+            if (retryDelay < 0) throw new NumberFormatException();
+        } catch (NumberFormatException exception) {
+            logger.severe("The retry delay must be a non-negative number!");
+            return;
+        }
+
         connect.setEnabled(false);
         connect.setText("Connecting...");
 
@@ -69,11 +93,11 @@ public class ConnectListener implements ActionListener {
         bots.removeIf(bot -> !bot.isOnline());
         while (bots.size() < amount) {
             int id = bots.size();
-
             ProtocolVersion version = ProtocolVersion.getByVersion((String) versionsBox.getSelectedItem());
             Logger botLogger = Logger.getLogger("Bot_" + id);
             botLogger.setParent(logger);
-            bots.addLast(version.getProtocol().newBot(botLogger, "Bot_" + id));
+            Bot bot = version.getProtocol().newBot(botLogger, "Bot_" + id);
+            bots.addLast(bot);
             botsBox.addItem("Bot_" + id);
         }
         while (bots.size() > amount) {
@@ -81,13 +105,72 @@ public class ConnectListener implements ActionListener {
             bot.disconnect("You left the server!");
             botsBox.removeItem(bot.getName());
         }
-        for (Bot client : bots) {
-            if (!client.isOnline()) {
-                client.connect(workerGroup, host, port);
+
+        new SwingWorker<Void, Void>() {
+            @Override
+            protected Void doInBackground() {
+                startBotLauncher(host, port, joinDelay, retryDelay);
+                return null;
             }
-        }
-        connect.setText("Connect");
-        connect.setEnabled(true);
+
+            @Override
+            protected void done() {
+                connect.setText("Connect");
+                connect.setEnabled(true);
+            }
+        }.execute();
     }
 
+    private void startBotLauncher(String host, int port, int joinDelay, int retryDelay) {
+        for (Bot bot : bots) {
+            while (!bot.isLoggedIn()) {
+                if (!bot.isOnline()) {
+                    bot.connect(workerGroup, host, port);
+                }
+                if (waitForLogin(bot, LOGIN_TIMEOUT_MS)) {
+                    break;
+                }
+
+                logger.warning(bot.getName() + " did not finish logging in, retrying...");
+                if (bot.isOnline()) {
+                    bot.disconnect("Retrying login");
+                }
+
+                try {
+                    Thread.sleep(retryDelay);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+
+            if (joinDelay > 0) {
+                try {
+                    Thread.sleep(joinDelay);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+        }
+    }
+
+    private static boolean waitForLogin(Bot bot, long timeoutMs) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            if (bot.isLoggedIn()) {
+                return true;
+            }
+            if (!bot.isOnline()) {
+                return false;
+            }
+            try {
+                Thread.sleep(50L);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+        }
+        return bot.isLoggedIn();
+    }
 }

--- a/bot-creator-main/src/main/java/ro/fr33styler/botcreator/gui/ConnectListener.java
+++ b/bot-creator-main/src/main/java/ro/fr33styler/botcreator/gui/ConnectListener.java
@@ -5,7 +5,9 @@ import ro.fr33styler.botcreator.BotLauncher;
 import ro.fr33styler.botcreator.bot.Bot;
 import ro.fr33styler.botcreator.bot.protocol.ProtocolVersion;
 
-import javax.swing.*;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JTextField;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.Deque;
@@ -105,18 +107,8 @@ public class ConnectListener implements ActionListener {
             botsBox.removeItem(bot.getName());
         }
 
-        new SwingWorker<Void, Void>() {
-            @Override
-            protected Void doInBackground() {
-                new BotLauncher(logger, bots, workerGroup, host, port, joinDelay, retryDelay).run();
-                return null;
-            }
-
-            @Override
-            protected void done() {
-                connect.setText("Connect");
-                connect.setEnabled(true);
-            }
-        }.execute();
+        new BotLauncher(logger, bots, workerGroup, host, port, joinDelay, retryDelay).start();
+        connect.setText("Connect");
+        connect.setEnabled(true);
     }
 }

--- a/bot-creator-main/src/main/java/ro/fr33styler/botcreator/gui/ConnectListener.java
+++ b/bot-creator-main/src/main/java/ro/fr33styler/botcreator/gui/ConnectListener.java
@@ -117,6 +117,8 @@ public class ConnectListener implements ActionListener {
             botsBox.removeItem(bot.getName());
         }
 
+        logLauncherSettings(amount, joinDelay, retryDelay, maxOnline);
+
         new SwingWorker<Void, Void>() {
             @Override
             protected Void doInBackground() {
@@ -134,9 +136,11 @@ public class ConnectListener implements ActionListener {
 
     private void startBotLauncher(String host, int port, int joinDelay, int retryDelay, int maxOnline) {
         while (!Thread.currentThread().isInterrupted()) {
-            int activeLimit = maxOnline > 0 ? Math.min(maxOnline, bots.size()) : bots.size();
+            int activeLimit = getActiveLimit(bots.size(), maxOnline);
             int checked = 0;
             boolean allLoggedIn = true;
+
+            disconnectAboveLimit(activeLimit);
 
             for (Bot bot : bots) {
                 if (checked++ >= activeLimit) {
@@ -155,6 +159,31 @@ public class ConnectListener implements ActionListener {
 
             if (allLoggedIn && !sleep(Math.max(1000, retryDelay))) {
                 return;
+            }
+        }
+    }
+
+    private void logLauncherSettings(int amount, int joinDelay, int retryDelay, int maxOnline) {
+        int activeLimit = getActiveLimit(amount, maxOnline);
+        String maxOnlineMessage = maxOnline > 0 ? String.valueOf(activeLimit) : "unlimited";
+        logger.info("Launcher settings: clients=" + amount + ", maxOnline=" + maxOnlineMessage + ", joinDelay=" + joinDelay + "ms, retryDelay=" + retryDelay + "ms");
+        if (maxOnline > 0 && activeLimit < amount) {
+            logger.info("Max online limit active: only Bot_0 through Bot_" + (activeLimit - 1) + " will be kept online.");
+        }
+    }
+
+    private static int getActiveLimit(int bots, int maxOnline) {
+        return maxOnline > 0 ? Math.min(maxOnline, bots) : bots;
+    }
+
+    private void disconnectAboveLimit(int activeLimit) {
+        int checked = 0;
+        for (Bot bot : bots) {
+            if (checked++ < activeLimit) {
+                continue;
+            }
+            if (bot.isOnline()) {
+                bot.disconnect("Max online limit reached");
             }
         }
     }

--- a/bot-creator-main/src/main/java/ro/fr33styler/botcreator/gui/ConnectListener.java
+++ b/bot-creator-main/src/main/java/ro/fr33styler/botcreator/gui/ConnectListener.java
@@ -24,11 +24,12 @@ public class ConnectListener implements ActionListener {
     private final JTextField clientsInput;
     private final JTextField joinDelayInput;
     private final JTextField retryDelayInput;
+    private final JTextField maxOnlineInput;
     private final JComboBox<String> versionsBox;
 
     private final JComboBox<String> botsBox;
 
-    public ConnectListener(Logger logger, Deque<Bot> bots, EventLoopGroup workerGroup, JTextField hostInput, JTextField portInput, JTextField clientsInput, JTextField joinDelayInput, JTextField retryDelayInput, JComboBox<String> versionsBox, JButton connect, JComboBox<String> botsBox) {
+    public ConnectListener(Logger logger, Deque<Bot> bots, EventLoopGroup workerGroup, JTextField hostInput, JTextField portInput, JTextField clientsInput, JTextField joinDelayInput, JTextField retryDelayInput, JTextField maxOnlineInput, JComboBox<String> versionsBox, JButton connect, JComboBox<String> botsBox) {
         this.logger = logger;
         this.bots = bots;
         this.workerGroup = workerGroup;
@@ -38,6 +39,7 @@ public class ConnectListener implements ActionListener {
         this.clientsInput = clientsInput;
         this.joinDelayInput = joinDelayInput;
         this.retryDelayInput = retryDelayInput;
+        this.maxOnlineInput = maxOnlineInput;
         this.versionsBox = versionsBox;
 
         this.connect = connect;
@@ -85,6 +87,15 @@ public class ConnectListener implements ActionListener {
             return;
         }
 
+        int maxOnline;
+        try {
+            maxOnline = Integer.parseInt(maxOnlineInput.getText());
+            if (maxOnline < 0) throw new NumberFormatException();
+        } catch (NumberFormatException exception) {
+            logger.severe("Max online must be a non-negative number!");
+            return;
+        }
+
         connect.setEnabled(false);
         connect.setText("Connecting...");
 
@@ -109,7 +120,7 @@ public class ConnectListener implements ActionListener {
         new SwingWorker<Void, Void>() {
             @Override
             protected Void doInBackground() {
-                startBotLauncher(host, port, joinDelay, retryDelay);
+                startBotLauncher(host, port, joinDelay, retryDelay, maxOnline);
                 return null;
             }
 
@@ -121,11 +132,16 @@ public class ConnectListener implements ActionListener {
         }.execute();
     }
 
-    private void startBotLauncher(String host, int port, int joinDelay, int retryDelay) {
+    private void startBotLauncher(String host, int port, int joinDelay, int retryDelay, int maxOnline) {
         while (!Thread.currentThread().isInterrupted()) {
+            int activeLimit = maxOnline > 0 ? Math.min(maxOnline, bots.size()) : bots.size();
+            int checked = 0;
             boolean allLoggedIn = true;
 
             for (Bot bot : bots) {
+                if (checked++ >= activeLimit) {
+                    break;
+                }
                 if (bot.isLoggedIn()) {
                     continue;
                 }

--- a/bot-creator-main/src/main/java/ro/fr33styler/botcreator/gui/ConnectListener.java
+++ b/bot-creator-main/src/main/java/ro/fr33styler/botcreator/gui/ConnectListener.java
@@ -122,36 +122,54 @@ public class ConnectListener implements ActionListener {
     }
 
     private void startBotLauncher(String host, int port, int joinDelay, int retryDelay) {
-        for (Bot bot : bots) {
-            while (!bot.isLoggedIn()) {
-                if (!bot.isOnline()) {
-                    bot.connect(workerGroup, host, port);
-                }
-                if (waitForLogin(bot, LOGIN_TIMEOUT_MS)) {
-                    break;
+        while (!Thread.currentThread().isInterrupted()) {
+            boolean allLoggedIn = true;
+
+            for (Bot bot : bots) {
+                if (bot.isLoggedIn()) {
+                    continue;
                 }
 
-                logger.warning(bot.getName() + " did not finish logging in, retrying...");
-                if (bot.isOnline()) {
-                    bot.disconnect("Retrying login");
-                }
-
-                try {
-                    Thread.sleep(retryDelay);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
+                allLoggedIn = false;
+                connectOnce(bot, host, port, retryDelay);
+                if (!sleep(joinDelay)) {
                     return;
                 }
             }
 
-            if (joinDelay > 0) {
-                try {
-                    Thread.sleep(joinDelay);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    return;
-                }
+            if (allLoggedIn && !sleep(Math.max(1000, retryDelay))) {
+                return;
             }
+        }
+    }
+
+    private void connectOnce(Bot bot, String host, int port, int retryDelay) {
+        if (!bot.isOnline()) {
+            bot.connect(workerGroup, host, port);
+        }
+
+        if (waitForLogin(bot, LOGIN_TIMEOUT_MS)) {
+            return;
+        }
+
+        logger.warning(bot.getName() + " did not finish logging in, retrying later...");
+        if (bot.isOnline()) {
+            bot.disconnect("Retrying login");
+        }
+
+        sleep(retryDelay);
+    }
+
+    private static boolean sleep(int delay) {
+        if (delay <= 0) {
+            return true;
+        }
+        try {
+            Thread.sleep(delay);
+            return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
         }
     }
 

--- a/bot-creator-main/src/main/java/ro/fr33styler/botcreator/gui/ConnectListener.java
+++ b/bot-creator-main/src/main/java/ro/fr33styler/botcreator/gui/ConnectListener.java
@@ -1,6 +1,7 @@
 package ro.fr33styler.botcreator.gui;
 
 import io.netty.channel.EventLoopGroup;
+import ro.fr33styler.botcreator.BotLauncher;
 import ro.fr33styler.botcreator.bot.Bot;
 import ro.fr33styler.botcreator.bot.protocol.ProtocolVersion;
 
@@ -12,9 +13,6 @@ import java.util.logging.Logger;
 
 public class ConnectListener implements ActionListener {
 
-    private static final long LOGIN_TIMEOUT_MS = 30000L;
-    private static final long CONNECT_TIMEOUT_MS = 5000L;
-
     private final Logger logger;
     private final Deque<Bot> bots;
     private final EventLoopGroup workerGroup;
@@ -25,12 +23,11 @@ public class ConnectListener implements ActionListener {
     private final JTextField clientsInput;
     private final JTextField joinDelayInput;
     private final JTextField retryDelayInput;
-    private final JTextField maxOnlineInput;
     private final JComboBox<String> versionsBox;
 
     private final JComboBox<String> botsBox;
 
-    public ConnectListener(Logger logger, Deque<Bot> bots, EventLoopGroup workerGroup, JTextField hostInput, JTextField portInput, JTextField clientsInput, JTextField joinDelayInput, JTextField retryDelayInput, JTextField maxOnlineInput, JComboBox<String> versionsBox, JButton connect, JComboBox<String> botsBox) {
+    public ConnectListener(Logger logger, Deque<Bot> bots, EventLoopGroup workerGroup, JTextField hostInput, JTextField portInput, JTextField clientsInput, JTextField joinDelayInput, JTextField retryDelayInput, JComboBox<String> versionsBox, JButton connect, JComboBox<String> botsBox) {
         this.logger = logger;
         this.bots = bots;
         this.workerGroup = workerGroup;
@@ -40,7 +37,6 @@ public class ConnectListener implements ActionListener {
         this.clientsInput = clientsInput;
         this.joinDelayInput = joinDelayInput;
         this.retryDelayInput = retryDelayInput;
-        this.maxOnlineInput = maxOnlineInput;
         this.versionsBox = versionsBox;
 
         this.connect = connect;
@@ -88,15 +84,6 @@ public class ConnectListener implements ActionListener {
             return;
         }
 
-        int maxOnline;
-        try {
-            maxOnline = Integer.parseInt(maxOnlineInput.getText());
-            if (maxOnline < 0) throw new NumberFormatException();
-        } catch (NumberFormatException exception) {
-            logger.severe("Max online must be a non-negative number!");
-            return;
-        }
-
         connect.setEnabled(false);
         connect.setText("Connecting...");
 
@@ -118,12 +105,10 @@ public class ConnectListener implements ActionListener {
             botsBox.removeItem(bot.getName());
         }
 
-        logLauncherSettings(amount, joinDelay, retryDelay, maxOnline);
-
         new SwingWorker<Void, Void>() {
             @Override
             protected Void doInBackground() {
-                startBotLauncher(host, port, joinDelay, retryDelay, maxOnline);
+                new BotLauncher(logger, bots, workerGroup, host, port, joinDelay, retryDelay).run();
                 return null;
             }
 
@@ -133,116 +118,5 @@ public class ConnectListener implements ActionListener {
                 connect.setEnabled(true);
             }
         }.execute();
-    }
-
-    private void startBotLauncher(String host, int port, int joinDelay, int retryDelay, int maxOnline) {
-        while (!Thread.currentThread().isInterrupted()) {
-            int activeLimit = getActiveLimit(bots.size(), maxOnline);
-            int checked = 0;
-            boolean allLoggedIn = true;
-
-            disconnectAboveLimit(activeLimit);
-
-            for (Bot bot : bots) {
-                if (checked++ >= activeLimit) {
-                    break;
-                }
-                if (bot.isLoggedIn()) {
-                    continue;
-                }
-
-                allLoggedIn = false;
-                if (!connectOnce(bot, host, port, retryDelay) || !sleep(joinDelay)) {
-                    return;
-                }
-            }
-
-            if (allLoggedIn && !sleep(Math.max(1000, retryDelay))) {
-                return;
-            }
-        }
-    }
-
-    private void logLauncherSettings(int amount, int joinDelay, int retryDelay, int maxOnline) {
-        int activeLimit = getActiveLimit(amount, maxOnline);
-        String maxOnlineMessage = maxOnline > 0 ? String.valueOf(activeLimit) : "unlimited";
-        logger.info("Launcher settings: clients=" + amount + ", maxOnline=" + maxOnlineMessage + ", joinDelay=" + joinDelay + "ms, retryDelay=" + retryDelay + "ms");
-        if (maxOnline > 0 && activeLimit < amount) {
-            logger.info("Max online limit active: only Bot_0 through Bot_" + (activeLimit - 1) + " will be kept online.");
-        }
-    }
-
-    private static int getActiveLimit(int bots, int maxOnline) {
-        return maxOnline > 0 ? Math.min(maxOnline, bots) : bots;
-    }
-
-    private void disconnectAboveLimit(int activeLimit) {
-        int checked = 0;
-        for (Bot bot : bots) {
-            if (checked++ < activeLimit) {
-                continue;
-            }
-            if (bot.isOnline()) {
-                bot.disconnect("Max online limit reached");
-            }
-        }
-    }
-
-    private boolean connectOnce(Bot bot, String host, int port, int retryDelay) {
-        if (!bot.isOnline()) {
-            bot.connect(workerGroup, host, port);
-        }
-
-        if (waitForLogin(bot, LOGIN_TIMEOUT_MS)) {
-            return true;
-        }
-
-        if (Thread.currentThread().isInterrupted()) {
-            return false;
-        }
-
-        logger.warning(bot.getName() + " did not finish logging in, retrying later...");
-        if (bot.isOnline()) {
-            bot.disconnect("Retrying login");
-        }
-
-        return sleep(retryDelay);
-    }
-
-    private static boolean sleep(int delay) {
-        if (delay <= 0) {
-            return true;
-        }
-        try {
-            Thread.sleep(delay);
-            return true;
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            return false;
-        }
-    }
-
-    private static boolean waitForLogin(Bot bot, long timeoutMs) {
-        long now = System.currentTimeMillis();
-        long deadline = now + timeoutMs;
-        long connectDeadline = now + CONNECT_TIMEOUT_MS;
-        boolean wasOnline = false;
-
-        while (now < deadline) {
-            if (bot.isLoggedIn()) {
-                return true;
-            }
-            if (bot.isOnline()) {
-                wasOnline = true;
-            } else if (wasOnline || now >= connectDeadline) {
-                return false;
-            }
-
-            if (!sleep(50)) {
-                return false;
-            }
-            now = System.currentTimeMillis();
-        }
-        return bot.isLoggedIn();
     }
 }

--- a/bot-creator-main/src/main/java/ro/fr33styler/botcreator/gui/ConnectListener.java
+++ b/bot-creator-main/src/main/java/ro/fr33styler/botcreator/gui/ConnectListener.java
@@ -13,6 +13,7 @@ import java.util.logging.Logger;
 public class ConnectListener implements ActionListener {
 
     private static final long LOGIN_TIMEOUT_MS = 30000L;
+    private static final long CONNECT_TIMEOUT_MS = 5000L;
 
     private final Logger logger;
     private final Deque<Bot> bots;
@@ -151,8 +152,7 @@ public class ConnectListener implements ActionListener {
                 }
 
                 allLoggedIn = false;
-                connectOnce(bot, host, port, retryDelay);
-                if (!sleep(joinDelay)) {
+                if (!connectOnce(bot, host, port, retryDelay) || !sleep(joinDelay)) {
                     return;
                 }
             }
@@ -188,13 +188,17 @@ public class ConnectListener implements ActionListener {
         }
     }
 
-    private void connectOnce(Bot bot, String host, int port, int retryDelay) {
+    private boolean connectOnce(Bot bot, String host, int port, int retryDelay) {
         if (!bot.isOnline()) {
             bot.connect(workerGroup, host, port);
         }
 
         if (waitForLogin(bot, LOGIN_TIMEOUT_MS)) {
-            return;
+            return true;
+        }
+
+        if (Thread.currentThread().isInterrupted()) {
+            return false;
         }
 
         logger.warning(bot.getName() + " did not finish logging in, retrying later...");
@@ -202,7 +206,7 @@ public class ConnectListener implements ActionListener {
             bot.disconnect("Retrying login");
         }
 
-        sleep(retryDelay);
+        return sleep(retryDelay);
     }
 
     private static boolean sleep(int delay) {
@@ -219,20 +223,25 @@ public class ConnectListener implements ActionListener {
     }
 
     private static boolean waitForLogin(Bot bot, long timeoutMs) {
-        long deadline = System.currentTimeMillis() + timeoutMs;
-        while (System.currentTimeMillis() < deadline) {
+        long now = System.currentTimeMillis();
+        long deadline = now + timeoutMs;
+        long connectDeadline = now + CONNECT_TIMEOUT_MS;
+        boolean wasOnline = false;
+
+        while (now < deadline) {
             if (bot.isLoggedIn()) {
                 return true;
             }
-            if (!bot.isOnline()) {
+            if (bot.isOnline()) {
+                wasOnline = true;
+            } else if (wasOnline || now >= connectDeadline) {
                 return false;
             }
-            try {
-                Thread.sleep(50L);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
+
+            if (!sleep(50)) {
                 return false;
             }
+            now = System.currentTimeMillis();
         }
         return bot.isLoggedIn();
     }

--- a/bot-creator-main/src/main/java/ro/fr33styler/botcreator/gui/Gui.java
+++ b/bot-creator-main/src/main/java/ro/fr33styler/botcreator/gui/Gui.java
@@ -37,6 +37,14 @@ public class Gui {
         JTextField clientsInput = new JTextField("1", 3);
         topPanel.add(clientsInput);
 
+        topPanel.add(new JLabel("Delay (ms): "));
+        JTextField joinDelayInput = new JTextField("1000", 5);
+        topPanel.add(joinDelayInput);
+
+        topPanel.add(new JLabel("Retry (ms): "));
+        JTextField retryDelayInput = new JTextField("3000", 5);
+        topPanel.add(retryDelayInput);
+
         JComboBox<String> versionsBox = new JComboBox<>();
         for (ProtocolVersion version : ProtocolVersion.values()) {
             versionsBox.addItem(version.getVersion());
@@ -46,7 +54,7 @@ public class Gui {
         JButton connect = new JButton("Connect");
 
         connect.addActionListener(new ConnectListener(logger, bots, workerGroup,
-                hostInput, portInput, clientsInput, versionsBox, connect, botsBox));
+                hostInput, portInput, clientsInput, joinDelayInput, retryDelayInput, versionsBox, connect, botsBox));
 
         topPanel.add(connect);
 

--- a/bot-creator-main/src/main/java/ro/fr33styler/botcreator/gui/Gui.java
+++ b/bot-creator-main/src/main/java/ro/fr33styler/botcreator/gui/Gui.java
@@ -45,10 +45,6 @@ public class Gui {
         JTextField retryDelayInput = new JTextField("3000", 5);
         topPanel.add(retryDelayInput);
 
-        topPanel.add(new JLabel("Max Online: "));
-        JTextField maxOnlineInput = new JTextField("0", 3);
-        topPanel.add(maxOnlineInput);
-
         JComboBox<String> versionsBox = new JComboBox<>();
         for (ProtocolVersion version : ProtocolVersion.values()) {
             versionsBox.addItem(version.getVersion());
@@ -58,7 +54,7 @@ public class Gui {
         JButton connect = new JButton("Connect");
 
         connect.addActionListener(new ConnectListener(logger, bots, workerGroup,
-                hostInput, portInput, clientsInput, joinDelayInput, retryDelayInput, maxOnlineInput, versionsBox, connect, botsBox));
+                hostInput, portInput, clientsInput, joinDelayInput, retryDelayInput, versionsBox, connect, botsBox));
 
         topPanel.add(connect);
 

--- a/bot-creator-main/src/main/java/ro/fr33styler/botcreator/gui/Gui.java
+++ b/bot-creator-main/src/main/java/ro/fr33styler/botcreator/gui/Gui.java
@@ -45,6 +45,10 @@ public class Gui {
         JTextField retryDelayInput = new JTextField("3000", 5);
         topPanel.add(retryDelayInput);
 
+        topPanel.add(new JLabel("Max Online: "));
+        JTextField maxOnlineInput = new JTextField("0", 3);
+        topPanel.add(maxOnlineInput);
+
         JComboBox<String> versionsBox = new JComboBox<>();
         for (ProtocolVersion version : ProtocolVersion.values()) {
             versionsBox.addItem(version.getVersion());
@@ -54,7 +58,7 @@ public class Gui {
         JButton connect = new JButton("Connect");
 
         connect.addActionListener(new ConnectListener(logger, bots, workerGroup,
-                hostInput, portInput, clientsInput, joinDelayInput, retryDelayInput, versionsBox, connect, botsBox));
+                hostInput, portInput, clientsInput, joinDelayInput, retryDelayInput, maxOnlineInput, versionsBox, connect, botsBox));
 
         topPanel.add(connect);
 


### PR DESCRIPTION
## Summary
- connect bots sequentially by waiting for each bot to finish login before starting the next
- keep retrying throttled or failed bots without stopping the whole batch
- add configurable retry delay support separate from join delay
- add death-message respawn handling and safer disconnect logging across protocol versions
- ignore local IDE and assistant metadata folders

## Validation
- mvn -q -DskipTests compile